### PR TITLE
Fix city label & note locations

### DIFF
--- a/src/output.h
+++ b/src/output.h
@@ -12,6 +12,7 @@
 #include <iosfwd>
 #include <iterator>
 #include <map>
+#include <stack>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -833,10 +833,6 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         geometry->rect( renderer, clipRect, SDL_Color() );
     }
 
-    // color blocks overlay; drawn on top of tiles and on top of overlay strings (if any).
-    color_block_overlay_container color_blocks;
-    // Strings with colors do be drawn with map_font on top of tiles.
-    std::multimap<point, formatted_text> overlay_strings;
     point s;
     get_window_tile_counts( width, height, s.x, s.y );
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -806,6 +806,24 @@ std::string cata_tiles::get_omt_id_rotation_and_subtile(
     return ot_type_id.id().str();
 }
 
+static point draw_string( Font &font,
+                          const SDL_Renderer_Ptr &renderer,
+                          const GeometryRenderer_Ptr &geometry,
+                          const std::string &str,
+                          point p,
+                          const unsigned char color )
+{
+    const char *cstr = str.c_str();
+    int len = str.length();
+    while( len > 0 ) {
+        const uint32_t ch32 = UTF8_getch( &cstr, &len );
+        const std::string ch = utf32_to_utf8( ch32 );
+        font.OutputChar( renderer, geometry, ch, p, color );
+        p.x += mk_wcwidth( ch32 ) * font.width;
+    }
+    return p;
+}
+
 void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_omt, bool blink )
 {
     if( !g ) {
@@ -1036,22 +1054,23 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         const auto abs_sm_to_draw_label = [&]( const tripoint_abs_sm & city_pos, const int label_length ) {
             const tripoint tile_draw_pos = global_omt_to_draw_position( project_to<coords::omt>
                                            ( city_pos ) ) - o;
-            point draw_point( tile_draw_pos.x * width / max_col, tile_draw_pos.y * height / max_row );
-            draw_point.x -= label_length * font->width;
-            draw_point.x += width / max_col;
+            point draw_point( tile_draw_pos.x * tile_width + dest.x,
+                              tile_draw_pos.y * tile_height + dest.y );
+            // center text on the tile
+            draw_point += point( ( tile_width - label_length * fontwidth ) / 2,
+                                 ( tile_height - fontheight ) / 2 );
             return draw_point;
         };
 
         // draws a black rectangle behind a label for visibility and legibility
         const auto label_bg = [&]( const tripoint_abs_sm & pos, const std::string & name ) {
-            const int name_length = name.length();
+            const int name_length = utf8_width( name );
             const point draw_pos = abs_sm_to_draw_label( pos, name_length );
             SDL_Rect clipRect = { draw_pos.x, draw_pos.y, name_length * fontwidth, fontheight };
 
             geometry->rect( renderer, clipRect, SDL_Color() );
 
-            const point label_pos( draw_pos + point( -( name.length() * fontwidth / 2 ), 0 ) );
-            map_font->OutputChar( renderer, geometry, name, label_pos, 11 );
+            draw_string( *font, renderer, geometry, name, draw_pos, 11 );
         };
 
         // the tiles on the overmap are overmap tiles, so we need to use
@@ -1108,11 +1127,9 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
         const auto draw_note_text = [&]( const point & draw_pos, const std::string & name,
         nc_color & color ) {
-            const int name_length = name.length();
-            const point label_pos( draw_pos + point( -( name.length() * fontwidth / 2 ), 0 ) );
             char note_fg_color = color == c_yellow ? 11 :
                                  cata_cursesport::colorpairs[color.to_color_pair_index()].FG;
-            map_font->OutputChar( renderer, geometry, name, label_pos, note_fg_color );
+            return draw_string( *font, renderer, geometry, name, draw_pos, note_fg_color );
         };
 
         // Find screen coordinates to the right of the center tile
@@ -1120,13 +1137,19 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                          center_abs_omt.y(), center_abs_omt.z() ) );
         const tripoint tile_draw_pos = global_omt_to_draw_position( project_to<coords::omt>
                                        ( center_sm ) ) - o;
-        point draw_point( tile_draw_pos.x * width / max_col, tile_draw_pos.y * height / max_row );
-        draw_point.x += width / max_col;
+        point draw_point( tile_draw_pos.x * tile_width + dest.x,
+                          tile_draw_pos.y * tile_height + dest.y );
+        draw_point += point( padding, padding );
 
         // Draw notes header. Very simple label at the moment
         nc_color header_color = c_white;
-        const std::string header_string = "-- Notes: --";
-        SDL_Rect header_background_rect = { draw_point.x - padding, draw_point.y - padding, fontwidth *static_cast<int>( header_string.length() ) + padding * 2, fontheight + padding * 2 };
+        const std::string header_string = _( "-- Notes: --" );
+        SDL_Rect header_background_rect = {
+            draw_point.x - padding,
+            draw_point.y - padding,
+            fontwidth * utf8_width( header_string ) + padding * 2,
+            fontheight + padding * 2
+        };
         geometry->rect( renderer, header_background_rect, SDL_Color{ 0, 0, 0, 175 } );
         draw_note_text( draw_point, header_string, header_color );
         draw_point.y += fontheight + padding * 2;
@@ -1158,18 +1181,22 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
                 nc_color &color = color_stack.empty() ? default_color : color_stack.top();
                 colored_lines.emplace_back( color, seg );
-                line_length += seg.length();
+                line_length += utf8_width( seg );
             }
 
             // Draw background first for the whole line
-            SDL_Rect background_rect = { draw_point.x - padding, draw_point.y - padding, fontwidth *line_length + padding * 2, fontheight + padding * 2 };
+            SDL_Rect background_rect = {
+                draw_point.x - padding,
+                draw_point.y - padding,
+                fontwidth *line_length + padding * 2,
+                fontheight + padding * 2
+            };
             geometry->rect( renderer, background_rect, SDL_Color{ 0, 0, 0, 175 } );
 
             // Draw colored text segments
             for( auto &colored_line : colored_lines ) {
                 std::string &text = std::get<1>( colored_line );
-                draw_note_text( draw_point, text, std::get<0>( colored_line ) );
-                draw_point.x += fontwidth * text.length();
+                draw_point.x = draw_note_text( draw_point, text, std::get<0>( colored_line ) ).x;
             }
 
             draw_point.y += fontheight + padding;
@@ -2405,6 +2432,7 @@ void draw_quick_shortcuts()
             text_x = ( ( i + 0.5f ) * width - ( font->width * utf8_width( text ) ) * text_scale * 0.5f ) /
                      text_scale;
         }
+        // TODO use draw_string instead
         text_y = ( WindowHeight - ( height + font->height * text_scale ) * 0.5f ) / text_scale;
         font->OutputChar( renderer, geometry, text, point( text_x + 1, text_y + 1 ), 0,
                           get_option<int>( "ANDROID_SHORTCUT_OPACITY_SHADOW" ) * 0.01f );


### PR DESCRIPTION
Sometimes city label and note's background and text do not strictliy align, when the overmap font and normal font has different sizes or when overmap window size is not dividable by the tile size.

This fixes it by:

1. Correctly implement string drawing. The `ch` parameter of `OutputChar` is assumed by `Font` classes to be a single utf-8 encoded unicode codepoint. Passing a string to `OutputChar` incidentally works, but the drawing position need to be hacked to correctly position the string, and `OutputChar` may render text incorrectly if characters after the first one needs to be drawn with a fallback font. There are also some android-specific code that needs to be updated to use `draw_string`, but I don't have the environment to test it, so I'll leave it for @ZhilkinSerg.
2. Use `utf8_width` to get the correct print length of strings.
3. Center city labels, and left and top-align notes.
4. Use `font` instead of `overmap_font`, because the code uses `fontwidth` and `fontheight` which are `font`'s properties.
5. Mark "Notes: " to be translated.
6. Remove some unused variables.